### PR TITLE
conf/gyroidos/tqma8mpxl: remove glibc patch which is in meta-oe

### DIFF
--- a/recipes-core/glibc/glibc_2.35.bbappend
+++ b/recipes-core/glibc/glibc_2.35.bbappend
@@ -1,0 +1,2 @@
+# workarround until upstream layer meta-tq is fixed
+SRC_URI:remove = "file://0002-sunrpc-Suppress-GCC-Os-warning-on-user2netname.patch"


### PR DESCRIPTION
There exist an upstream PR to meta-tq layer: "kirkstone: drop backport patch now hosted by openembedded-core #8" including folloing commit:
    meta-tq: glibc: drop backport patch now provided by openembedded-core

    glibc recipe no longer requires the backport patch. Same patch
    is now provided directly by openembedded-core,
    [ref 78fac0f623e01bd52b2ea3a597d056726deca8a4]

    https://patchwork.yoctoproject.org/project/oe-core/patch/20250204065526.3999-1-nikhilar2410@gmail.com/

However, since this is not merged, we have to remove the corresponding path here.