### PR TITLE
Revert "conf/gyroidos/tqma8mpxl: Do not set image type"

### DIFF
--- a/conf/gyroidos/tqma8mpxl.inc
+++ b/conf/gyroidos/tqma8mpxl.inc
@@ -12,6 +12,8 @@ GYROIDOS_FSTYPES = "wic wic.bmap"
 
 BBMULTICONFIG = "guestos"
 PACKAGE_CLASSES = "package_ipk"
+KERNEL_CLASSES:append = " kernel-fitimage "
+KERNEL_IMAGETYPE:tqma8mpxl = "fitImage"
 
 IMAGE_BOOT_FILES:tqma8mpxl = "${KERNEL_DEPLOYSUBDIR}/fitImage-gyroidos-cml-initramfs-${MACHINE}-${MACHINE};fitImage-gyroidos-cml-initramfs"
 WKS_FILE:tqma8mpxl = "tqma8mpxl.wks.in"


### PR DESCRIPTION
This reverts commit 9e59c518e9b6ac1ed3d44bbf18a06de9a8807343.