### PR TITLE
Layerscape signed images

### DIFF
--- a/images/gyroidos-cml.bbappend
+++ b/images/gyroidos-cml.bbappend
@@ -3,6 +3,10 @@ INITRAMFS_IMAGE_BUNDLE = "0"
 KERNEL_IMAGE_FILE = "cml-kernel/fitImage-gyroidos-cml-initramfs-${MACHINE}-${MACHINE}"
 OS_CONFIG_IN := "${THISDIR}/${PN}/${MACHINE}.conf"
 
+# tqmlx2160a-mblx2160a + ls1088ardb-pb
+DEPENDS:append:qoriq = "qoriq-signed-images"
+
+# tqma8mpxl-mba8mpxl customization
 do_sign_guestos:prepend:tqma8mpxl-mba8mpxl () {
         mkdir -p "${UPDATE_OUT}"
         cp "${DEPLOY_DIR_IMAGE}/${MACHINE_WKS_BOOTSTREAM}" "${UPDATE_OUT}/bootloader.img"
@@ -12,6 +16,7 @@ do_sign_guestos:prepend:tqma8mpxl-mba8mpxl () {
         cp "${WORKDIR}/device.conf" "${UPDATE_OUT}/device.img"
 }
 
+# tqmlx2160a-mblx2160a customization
 do_sign_guestos:prepend:tqmlx2160a-mblx2160a () {
         mkdir -p "${UPDATE_OUT}"
         cp "${DEPLOY_DIR_IMAGE}/${GYROIDOS_BOOTSTREAM0}" "${UPDATE_OUT}/bootloader0.img"
@@ -22,6 +27,14 @@ do_sign_guestos:prepend:tqmlx2160a-mblx2160a () {
         cp "${WORKDIR}/device.conf" "${UPDATE_OUT}/device.img"
 }
 
+IMAGE_BOOT_FILES:append:tqmlx2160a-mblx2160a = " \
+	${KERNEL_DEPLOYSUBDIR}/fitImage-gyroidos-cml-initramfs-${MACHINE}-${MACHINE}.hdr;fitImage-gyroidos-cml-initramfs.hdr \
+	mc_app/mc.itb.hdr;mc.itb.hdr \
+	mc-utils/${MC_DPC}.hdr;dpc-warn.dtb.hdr \
+	mc-utils/${MC_DPL}.hdr;dpl-min.dtb.hdr \
+	"
+
+# ls1088ardb-pb customization
 do_sign_guestos:prepend:ls1088ardb-pb () {
         mkdir -p "${UPDATE_OUT}"
         cp "${DEPLOY_DIR_IMAGE}/${GYROIDOS_BOOTSTREAM0}" "${UPDATE_OUT}/bootloader0.img"
@@ -31,3 +44,10 @@ do_sign_guestos:prepend:ls1088ardb-pb () {
         cp "${DEPLOY_DIR_IMAGE}/gyroidos-cml-modules-${MACHINE}.squashfs" "${UPDATE_OUT}/modules.img"
         cp "${WORKDIR}/device.conf" "${UPDATE_OUT}/device.img"
 }
+
+IMAGE_BOOT_FILES:append:ls1088ardb-pb = " \
+	${KERNEL_DEPLOYSUBDIR}/fitImage-gyroidos-cml-initramfs-${MACHINE}-${MACHINE}.hdr;fitImage-gyroidos-cml-initramfs.hdr \
+	mc_app/mc.itb.hdr;mc.itb.hdr \
+	mc-utils/${MC_DPC}.hdr;dpc.dtb.hdr \
+	mc-utils/${MC_DPL}.hdr;dpl.dtb.hdr \
+	"

--- a/images/qoriq-signed-images.bb
+++ b/images/qoriq-signed-images.bb
@@ -1,0 +1,36 @@
+DESCRIPTION = "Signed firmware images"
+
+inherit image
+
+DEPENDS += "qoriq-cst-native"
+do_image[depends] = "virtual/kernel:do_deploy"
+
+sign_fw_file () {
+	script="$1"
+	sub_path="$2"
+	outfile="$3"
+	tmpfile="$4"
+
+	bbnote "Signing $sub_path"
+
+	cp ${DEPLOY_DIR_IMAGE}/$sub_path $tmpfile
+	./uni_sign input_files/uni_sign/$script
+	mkdir -p "$(dirname ${IMGDEPLOYDIR}/$sub_path)"
+	cp $outfile "${IMGDEPLOYDIR}/$sub_path.hdr"
+}
+
+UNI_SIGN_SCRIPTS_DIR:tqmlx2160a-mblx2160a = "lx2160"
+UNI_SIGN_SCRIPTS_DIR:ls1088ardb-pb = "ls2088_1088"
+
+do_image () {
+	cd ${WORKDIR}
+	cp -r ${RECIPE_SYSROOT_NATIVE}/usr/bin/cst .
+	cd cst
+
+	sign_fw_file ${UNI_SIGN_SCRIPTS_DIR}/sd/input_mc_secure mc_app/mc.itb hdr_mc.out mc.itb
+	sign_fw_file ${UNI_SIGN_SCRIPTS_DIR}/sd/input_dpc_secure mc-utils/${MC_DPC} hdr_dpc.out dpc.dtb
+	sign_fw_file ${UNI_SIGN_SCRIPTS_DIR}/sd/input_dpl_secure mc-utils/${MC_DPL} hdr_dpl.out dpl.dtb
+	sign_fw_file ${UNI_SIGN_SCRIPTS_DIR}/input_kernel_secure \
+		     ${KERNEL_DEPLOYSUBDIR}/fitImage-gyroidos-cml-initramfs-${MACHINE}-${MACHINE} \
+		     hdr_kernel.out kernel.itb
+}


### PR DESCRIPTION
Install the signatures that are generated in qoriq-signed-images via
IMAGE_BOOT_FILES.