### PR TITLE
tqmlx2160a: introduce GYROIDOS_DDR_IMAGE variable

### DIFF
--- a/conf/gyroidos/tqmlx2160a.inc
+++ b/conf/gyroidos/tqmlx2160a.inc
@@ -17,6 +17,9 @@ KERNEL_CLASSES:append = " kernel-fitimage "
 KERNEL_IMAGETYPE:tqmlx2160a = "${@bb.utils.contains('DISTRO_CODENAME', 'kirkstone', 'fitImage', '', d)}"
 PACKAGE_CLASSES = "package_ipk"
 
+GYROID_DDR_IMAGE:tddqmlx2160a ?= "ddr-phy/fip_ddr.bin"
+GYROIDOS_DDR_IMAGE:tqmlx2160a = "${@bb.utils.contains('DISTRO_CODENAME', 'kirkstone', 'ddr-phy/fip_ddr.bin', 'atf/${DDR_IMAGE}', d)}"
+
 IMAGE_BOOT_FILES:append:tqmlx2160a = " ${KERNEL_DEPLOYSUBDIR}/fitImage-gyroidos-cml-initramfs-${MACHINE}-${MACHINE};fitImage-gyroidos-cml-initramfs"
 #IMAGE_BOOT_FILES:append:tqmlx2160a = " ${KERNEL_DEPLOYSUBDIR}/Image;Image"
 GYROIDOS_BOOTSTREAM0= "atf/${BL2_IMAGE}"

--- a/wic/tqmlx2160a.wks.in
+++ b/wic/tqmlx2160a.wks.in
@@ -19,7 +19,7 @@
 part rcw_pbi --source rawcopy --sourceparams="file=atf/${BL2_IMAGE}" --no-table --offset 4K --fixed-size 1020K
 part u-boot --source rawcopy --sourceparams="file=atf/${BL3_IMAGE}" --no-table --offset 1M --fixed-size 2M
 part uboot-env --no-table --offset 5M --fixed-size 3M
-part ddr_phy_firmware --source rawcopy --sourceparams="file=ddr-phy/fip_ddr.bin" --no-table --offset 8M --fixed-size 8M
+part ddr_phy_firmware --source rawcopy --sourceparams="file=${GYROIDOS_DDR_IMAGE}" --no-table --offset 8M --fixed-size 8M
 part /boot --source bootimg-partition --fstype=vfat --label boot --active --offset 16M --size 32M
 part / --source rootfs --fstype=ext4 --label gyroidos --align 4096 --extra-space ${GYROIDOS_DATAPART_EXTRA_SPACE}M
 


### PR DESCRIPTION
In conf/gyroidos/tqmlx2160a.inc, we added the new variable GYROIDOS_DDR_IMAGE which is set on tqmlx2160a only. This is used in the corresponding wic image wic/tqmlx2160a.wks.in.

This reflects the current change in upstream meta-tq repo, where the ddr firmware file was moved:

   commit b1c12d8a799403bf948f40816b017d081bc6098e
   Author: Matthias Schiffer <matthias.schiffer@tq-group.com>
   Date:   Tue Jul 29 10:37:45 2025 +0200

   meta-tq: machine: tqmlx2160a: add support for Secure Boot

   Use BL2, BL3 and DDR firmware with "_sec" suffix when the "secure" distro
   feature is enabled.

   Signed-off-by: Matthias Schiffer <matthias.schiffer@tq-group.com>