### PR TITLE
recipes-devtools/qoriq-cst: Inherit p11-signing

### DIFF
--- a/recipes-devtools/qoriq-cst/qoriq-cst_%.bbappend
+++ b/recipes-devtools/qoriq-cst/qoriq-cst_%.bbappend
@@ -2,6 +2,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " file://0001-common-Initialize-ret-in-create_srk_clac_hash-to-all.patch"
 
+inherit p11-signing
+
 do_install:append () {
     if [ -n "${SECURE_PRI_KEY}" ]; then
         openssl rsa -in ${D}/${bindir}/cst/srk.pri -traditional -out ${D}/${bindir}/cst/srk.pri


### PR DESCRIPTION
Currently, qoriq-cst runs into having no PKI being generated before it runs, as we are missing a dependency edge onto the pki-native:do_compile task.
Inherit p11-signing. This add the missing edge.